### PR TITLE
Fix: Plugin breaks new topic button

### DIFF
--- a/assets/javascripts/discourse/initializers/presence-router.js.es6
+++ b/assets/javascripts/discourse/initializers/presence-router.js.es6
@@ -24,6 +24,10 @@ export default {
       }),
 
       addUser: function () {
+        // Skip if this is a new topic
+        if(typeof topic == 'undefined')
+          return
+
         controller.setProperties({ presenceWritingClass: 'hide', presenceWriting: "", users: [] });
         ajax('/presence/writing/' + topic.id + '/add', {method: 'GET'}).then(
           function(){
@@ -74,6 +78,10 @@ export default {
       },
 
       alive: function () {
+        // Skip if this is a new topic
+        if(typeof topic == 'undefined')
+          return
+
         ajax('/presence/writing/' + topic.id + '/alive', {method: 'GET'}).then(function(){
         }.bind(this), function(){
           // Remove the time if there's an error
@@ -82,6 +90,10 @@ export default {
       },
 
       removeUser: function () {
+        // Skip if this is a new topic
+        if(typeof topic == 'undefined')
+          return
+
         clearInterval(presenceTimer);
         controller.setProperties({ presenceWritingClass: 'hide', presenceWriting: "", users: [] });
         const self = this;


### PR DESCRIPTION
Clicking on the New Topic button causes an error because `topic` is undefined.

<img width="398" alt="screen shot 2016-12-15 at 8 21 22 pm" src="https://cloud.githubusercontent.com/assets/597182/21224820/f4fbc4b4-c308-11e6-9159-7befeccbd600.png">
<img width="730" alt="screen shot 2016-12-15 at 8 32 20 pm" src="https://cloud.githubusercontent.com/assets/597182/21224825/f784ad9a-c308-11e6-8133-0701c6ef0154.png">

This pull request fixes it by only executing the hooks if `topic` is defined.
